### PR TITLE
Fix deb/rpm install path containing spaces

### DIFF
--- a/Casks/azeron-software.rb
+++ b/Casks/azeron-software.rb
@@ -10,5 +10,5 @@ cask "azeron-software" do
   depends_on macos: ">= :sonoma"
   depends_on arch: :arm64
 
-  app "Azeron Software.app"
+  app "azeron-software.app"
 end

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "build": {
     "appId": "com.azeron.software",
-    "productName": "Azeron Software",
+    "productName": "azeron-software",
     "artifactName": "azeron-software-${version}-${arch}.${ext}",
     "directories": {
       "app": "app",


### PR DESCRIPTION
## Summary
- Changed `productName` from `"Azeron Software"` to `"azeron-software"` so the install directory becomes `/opt/azeron-software/` instead of `/opt/Azeron Software/`
- The space in the path caused Chromium's zygote `execvp` to fail on Ubuntu, crashing the app at launch
- Desktop entry display name is unaffected — it's explicitly set to "Azeron Software" via `linux.desktop.Name`
- Updated macOS Cask to reference the new `.app` bundle name

## Details
The `productName` in electron-builder determines the install directory for deb/rpm packages via FPM. With `"Azeron Software"`, the install path `/opt/Azeron Software/` contained a space that broke the SUID sandbox helper's `execvp` call (`LaunchProcess: failed to execvp: /opt/Azeron`).

This also aligns with the PKGBUILD which already installs to `/opt/azeron-software/`.

Fixes #7

## Test plan
- [x] Build `.deb` package and verify it installs to `/opt/azeron-software/`
- [x] Verify the app launches without the `execvp` / zygote crash on Ubuntu
- [x] Verify the desktop entry still shows "Azeron Software" in app launchers
- [x] Verify macOS build produces `azeron-software.app` and the Cask installs correctly