### PR TITLE
Linux: install udev rules to /etc/udev/rules.d on .deb / .rpm install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
           - os: ubuntu-22.04
             target: linux
             patch_cmd: npm run patch
-            build_cmd: npx electron-builder --linux AppImage
+            build_cmd: npx electron-builder --linux AppImage deb rpm
           - os: macos-14
             target: darwin
             patch_cmd: npm run patch:mac

--- a/package.json
+++ b/package.json
@@ -117,10 +117,14 @@
     },
     "deb": {
       "depends": ["libhidapi-hidraw0", "libusb-1.0-0"],
-      "recommends": ["dfu-util"]
+      "recommends": ["dfu-util"],
+      "afterInstall": "scripts/deb/after-install.sh",
+      "afterRemove": "scripts/deb/after-remove.sh"
     },
     "rpm": {
-      "depends": ["hidapi", "libusb1", "dfu-util"]
+      "depends": ["hidapi", "libusb1", "dfu-util"],
+      "afterInstall": "scripts/rpm/after-install.sh",
+      "afterRemove": "scripts/rpm/after-remove.sh"
     },
     "pacman": {
       "depends": [

--- a/scripts/deb/after-install.sh
+++ b/scripts/deb/after-install.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# .deb postinst — combines electron-builder's default linux postinst
+# (update-alternatives symlink, chrome-sandbox SUID, mime/desktop database
+# refresh) with the Azeron-specific udev rule install. Variables in
+# ${...} are substituted by electron-builder before this script lands in
+# the .deb (see node_modules/app-builder-lib/templates/linux/after-install.tpl).
+
+# --- electron-builder default ---------------------------------------------
+
+if type update-alternatives 2>/dev/null >&1; then
+    # Remove previous link if it doesn't use update-alternatives
+    if [ -L '/usr/bin/${executable}' -a -e '/usr/bin/${executable}' -a "`readlink '/usr/bin/${executable}'`" != '/etc/alternatives/${executable}' ]; then
+        rm -f '/usr/bin/${executable}'
+    fi
+    update-alternatives --install '/usr/bin/${executable}' '${executable}' '/opt/${sanitizedProductName}/${executable}' 100 || ln -sf '/opt/${sanitizedProductName}/${executable}' '/usr/bin/${executable}'
+else
+    ln -sf '/opt/${sanitizedProductName}/${executable}' '/usr/bin/${executable}'
+fi
+
+# Check if user namespaces are supported by the kernel and working with a quick test:
+if ! { [[ -L /proc/self/ns/user ]] && unshare --user true; }; then
+    # Use SUID chrome-sandbox only on systems without user namespaces:
+    chmod 4755 '/opt/${sanitizedProductName}/chrome-sandbox' || true
+else
+    chmod 0755 '/opt/${sanitizedProductName}/chrome-sandbox' || true
+fi
+
+if hash update-mime-database 2>/dev/null; then
+    update-mime-database /usr/share/mime || true
+fi
+
+if hash update-desktop-database 2>/dev/null; then
+    update-desktop-database /usr/share/applications || true
+fi
+
+# --- Azeron udev rules ----------------------------------------------------
+# The .deb ships the udev rules at /opt/${sanitizedProductName}/udev/99-azeron.rules
+# but they need to be at /etc/udev/rules.d/99-azeron.rules for the kernel to
+# apply them. Without this, users hit "cannot open device with path
+# /dev/hidraw*" because the default permission mask blocks non-root access
+# (see issue #21).
+
+UDEV_SRC='/opt/${sanitizedProductName}/udev/99-azeron.rules'
+UDEV_DST='/etc/udev/rules.d/99-azeron.rules'
+
+if [ -f "$UDEV_SRC" ]; then
+    install -m 644 "$UDEV_SRC" "$UDEV_DST"
+    if command -v udevadm >/dev/null 2>&1; then
+        udevadm control --reload-rules || true
+        udevadm trigger --subsystem-match=hidraw --subsystem-match=usb --action=change || true
+    fi
+    echo "Azeron udev rules installed at $UDEV_DST."
+    echo "If your Azeron is currently connected, unplug and replug it for the rules to apply."
+else
+    echo "Warning: $UDEV_SRC not found; install udev rules manually from /opt/${sanitizedProductName}/udev/." >&2
+fi
+
+exit 0

--- a/scripts/deb/after-remove.sh
+++ b/scripts/deb/after-remove.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# .deb postrm — combines electron-builder's default (drop update-alternatives
+# symlink) with removal of the Azeron udev rule. Variables in ${...} are
+# substituted by electron-builder before install.
+
+# --- electron-builder default ---------------------------------------------
+
+# Delete the link to the binary
+if type update-alternatives >/dev/null 2>&1; then
+    update-alternatives --remove '${executable}' '/usr/bin/${executable}'
+else
+    rm -f '/usr/bin/${executable}'
+fi
+
+# --- Azeron udev rules ----------------------------------------------------
+
+UDEV_DST='/etc/udev/rules.d/99-azeron.rules'
+
+if [ -f "$UDEV_DST" ]; then
+    rm -f "$UDEV_DST"
+    if command -v udevadm >/dev/null 2>&1; then
+        udevadm control --reload-rules || true
+    fi
+fi
+
+exit 0

--- a/scripts/deb/after-remove.sh
+++ b/scripts/deb/after-remove.sh
@@ -2,6 +2,12 @@
 # .deb postrm — combines electron-builder's default (drop update-alternatives
 # symlink) with removal of the Azeron udev rule. Variables in ${...} are
 # substituted by electron-builder before install.
+#
+# dpkg invokes postrm with $1 in {remove, purge, upgrade, failed-upgrade,
+# abort-install, abort-upgrade, disappear}. Gate the udev-rule removal on
+# remove/purge so an upgrade — where this script runs after files are
+# unpacked, before the new postinst — doesn't undo the new package's setup
+# if the new postinst then fails.
 
 # --- electron-builder default ---------------------------------------------
 
@@ -14,12 +20,14 @@ fi
 
 # --- Azeron udev rules ----------------------------------------------------
 
-UDEV_DST='/etc/udev/rules.d/99-azeron.rules'
+if [ "$1" = "remove" ] || [ "$1" = "purge" ]; then
+    UDEV_DST='/etc/udev/rules.d/99-azeron.rules'
 
-if [ -f "$UDEV_DST" ]; then
-    rm -f "$UDEV_DST"
-    if command -v udevadm >/dev/null 2>&1; then
-        udevadm control --reload-rules || true
+    if [ -f "$UDEV_DST" ]; then
+        rm -f "$UDEV_DST"
+        if command -v udevadm >/dev/null 2>&1; then
+            udevadm control --reload-rules || true
+        fi
     fi
 fi
 

--- a/scripts/rpm/after-install.sh
+++ b/scripts/rpm/after-install.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-# .deb postinst — combines electron-builder's default linux postinst
+# .rpm postinstall — combines electron-builder's default linux postinst
 # (update-alternatives symlink, chrome-sandbox SUID, mime/desktop database
 # refresh) with the Azeron-specific udev rule install. Variables in
 # ${...} are substituted by electron-builder before this script lands in
-# the .deb (see node_modules/app-builder-lib/templates/linux/after-install.tpl).
+# the .rpm (see node_modules/app-builder-lib/templates/linux/after-install.tpl).
 
 # --- electron-builder default ---------------------------------------------
 

--- a/scripts/rpm/after-install.sh
+++ b/scripts/rpm/after-install.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# .deb postinst — combines electron-builder's default linux postinst
+# (update-alternatives symlink, chrome-sandbox SUID, mime/desktop database
+# refresh) with the Azeron-specific udev rule install. Variables in
+# ${...} are substituted by electron-builder before this script lands in
+# the .deb (see node_modules/app-builder-lib/templates/linux/after-install.tpl).
+
+# --- electron-builder default ---------------------------------------------
+
+if type update-alternatives 2>/dev/null >&1; then
+    # Remove previous link if it doesn't use update-alternatives
+    if [ -L '/usr/bin/${executable}' -a -e '/usr/bin/${executable}' -a "`readlink '/usr/bin/${executable}'`" != '/etc/alternatives/${executable}' ]; then
+        rm -f '/usr/bin/${executable}'
+    fi
+    update-alternatives --install '/usr/bin/${executable}' '${executable}' '/opt/${sanitizedProductName}/${executable}' 100 || ln -sf '/opt/${sanitizedProductName}/${executable}' '/usr/bin/${executable}'
+else
+    ln -sf '/opt/${sanitizedProductName}/${executable}' '/usr/bin/${executable}'
+fi
+
+# Check if user namespaces are supported by the kernel and working with a quick test:
+if ! { [[ -L /proc/self/ns/user ]] && unshare --user true; }; then
+    # Use SUID chrome-sandbox only on systems without user namespaces:
+    chmod 4755 '/opt/${sanitizedProductName}/chrome-sandbox' || true
+else
+    chmod 0755 '/opt/${sanitizedProductName}/chrome-sandbox' || true
+fi
+
+if hash update-mime-database 2>/dev/null; then
+    update-mime-database /usr/share/mime || true
+fi
+
+if hash update-desktop-database 2>/dev/null; then
+    update-desktop-database /usr/share/applications || true
+fi
+
+# --- Azeron udev rules ----------------------------------------------------
+# The .deb ships the udev rules at /opt/${sanitizedProductName}/udev/99-azeron.rules
+# but they need to be at /etc/udev/rules.d/99-azeron.rules for the kernel to
+# apply them. Without this, users hit "cannot open device with path
+# /dev/hidraw*" because the default permission mask blocks non-root access
+# (see issue #21).
+
+UDEV_SRC='/opt/${sanitizedProductName}/udev/99-azeron.rules'
+UDEV_DST='/etc/udev/rules.d/99-azeron.rules'
+
+if [ -f "$UDEV_SRC" ]; then
+    install -m 644 "$UDEV_SRC" "$UDEV_DST"
+    if command -v udevadm >/dev/null 2>&1; then
+        udevadm control --reload-rules || true
+        udevadm trigger --subsystem-match=hidraw --subsystem-match=usb --action=change || true
+    fi
+    echo "Azeron udev rules installed at $UDEV_DST."
+    echo "If your Azeron is currently connected, unplug and replug it for the rules to apply."
+else
+    echo "Warning: $UDEV_SRC not found; install udev rules manually from /opt/${sanitizedProductName}/udev/." >&2
+fi
+
+exit 0

--- a/scripts/rpm/after-remove.sh
+++ b/scripts/rpm/after-remove.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# .deb postrm — combines electron-builder's default (drop update-alternatives
+# symlink) with removal of the Azeron udev rule. Variables in ${...} are
+# substituted by electron-builder before install.
+
+# --- electron-builder default ---------------------------------------------
+
+# Delete the link to the binary
+if type update-alternatives >/dev/null 2>&1; then
+    update-alternatives --remove '${executable}' '/usr/bin/${executable}'
+else
+    rm -f '/usr/bin/${executable}'
+fi
+
+# --- Azeron udev rules ----------------------------------------------------
+
+UDEV_DST='/etc/udev/rules.d/99-azeron.rules'
+
+if [ -f "$UDEV_DST" ]; then
+    rm -f "$UDEV_DST"
+    if command -v udevadm >/dev/null 2>&1; then
+        udevadm control --reload-rules || true
+    fi
+fi
+
+exit 0

--- a/scripts/rpm/after-remove.sh
+++ b/scripts/rpm/after-remove.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
-# .deb postrm — combines electron-builder's default (drop update-alternatives
-# symlink) with removal of the Azeron udev rule. Variables in ${...} are
-# substituted by electron-builder before install.
+# .rpm postuninstall — combines electron-builder's default (drop
+# update-alternatives symlink) with removal of the Azeron udev rule.
+# Variables in ${...} are substituted by electron-builder before install.
+#
+# RPM scriptlet arg: $1 = remaining install count after the operation.
+#   0 = full uninstall, 1 = upgrade (new version still installed).
+# Gate the udev-rule removal on $1=0 so an upgrade doesn't wipe the
+# rule that the new package's %post just installed.
 
 # --- electron-builder default ---------------------------------------------
 
@@ -14,12 +19,14 @@ fi
 
 # --- Azeron udev rules ----------------------------------------------------
 
-UDEV_DST='/etc/udev/rules.d/99-azeron.rules'
+if [ "$1" = "0" ]; then
+    UDEV_DST='/etc/udev/rules.d/99-azeron.rules'
 
-if [ -f "$UDEV_DST" ]; then
-    rm -f "$UDEV_DST"
-    if command -v udevadm >/dev/null 2>&1; then
-        udevadm control --reload-rules || true
+    if [ -f "$UDEV_DST" ]; then
+        rm -f "$UDEV_DST"
+        if command -v udevadm >/dev/null 2>&1; then
+            udevadm control --reload-rules || true
+        fi
     fi
 fi
 


### PR DESCRIPTION
## Problem

In #21, [@DefectiveChaos](https://github.com/DefectiveChaos) reports the app stuck on "select your device" on Linux Mint installed via `.deb`, with the terminal logging:

> Failed to open HID device: cannot open device with path /dev/hidraw7

That's a permissions error on `/dev/hidraw*` — the default permission mask doesn't let non-root processes open the node, and the udev rule that fixes that (`MODE="0666"` for `idVendor=16d0`) never gets installed.

The repo already has the right rule (`assets/99-azeron.rules`). It ships inside the `.deb` at `/opt/azeron-software/udev/99-azeron.rules`, but no install hook moves it into `/etc/udev/rules.d/` where udev actually reads it. The AUR `PKGBUILD` already installs to `/usr/lib/udev/rules.d/` correctly; `.deb` / `.rpm` did not.

## Fix

Add `afterInstall` / `afterRemove` scripts for `.deb` and `.rpm` that:

1. Run electron-builder's existing default content (update-alternatives symlink, chrome-sandbox SUID, mime/desktop database refresh) — these have to be preserved because `afterInstall` *replaces* the default template, not appends to it.
2. Install `99-azeron.rules` to `/etc/udev/rules.d/`, run `udevadm control --reload-rules`, then `udevadm trigger --subsystem-match=hidraw --subsystem-match=usb --action=change`.
3. Symmetric removal in postrm.

Also collapses two pre-existing duplicate `"deb"` / `"rpm"` blocks in `package.json` that were silently overriding each other (the lower one with `depends` won; the upper one with anything else was lost). Found this debugging the first build attempt — that's why the merged config now has `depends`, `recommends`, `afterInstall`, `afterRemove` all in one block.

CI workflow is extended to build `deb` + `rpm` in addition to `AppImage` so the postinst is exercised on every PR going forward.

## Verified

CI run on the fork: https://github.com/InfiniteLoopAlchemist/azeron-linux/actions/runs/25530595559

Pulled the resulting `.deb` artifact and inspected the control archive with `dpkg-deb -e`. The generated postinst contains both blocks correctly, with electron-builder's `${executable}` substituted to `azeron-software-v1` and `${sanitizedProductName}` to `azeron-software`:

```bash
#!/bin/bash
# .deb postinst — combines electron-builder's default linux postinst …

# --- electron-builder default ---------------------------------------------

if type update-alternatives 2>/dev/null >&1; then
    …
    update-alternatives --install '/usr/bin/azeron-software-v1' 'azeron-software-v1' '/opt/azeron-software/azeron-software-v1' 100 || …
…
fi

# (chrome-sandbox SUID, mime, desktop-db blocks)

# --- Azeron udev rules ----------------------------------------------------

UDEV_SRC='/opt/azeron-software/udev/99-azeron.rules'
UDEV_DST='/etc/udev/rules.d/99-azeron.rules'

if [ -f "$UDEV_SRC" ]; then
    install -m 644 "$UDEV_SRC" "$UDEV_DST"
    if command -v udevadm >/dev/null 2>&1; then
        udevadm control --reload-rules || true
        udevadm trigger --subsystem-match=hidraw --subsystem-match=usb --action=change || true
    fi
…
fi
```

## Not yet verified

Author doesn't have a Linux Mint box on hand, so this hasn't been confirmed end-to-end against DefectiveChaos's exact symptom. The static chain (postinst runs → rule lands in `/etc/udev/rules.d/` → `udevadm trigger` re-applies → `/dev/hidraw*` becomes `0666` for `idVendor=16d0`) is the same mechanism the AUR `PKGBUILD` already uses successfully against the same VID. Validation from someone on a `.deb`-based distro before merge would be welcome.

## Test plan

- [ ] CI green (deb + rpm + AppImage build)
- [ ] `dpkg-deb -e` of the produced `.deb` shows both blocks in postinst
- [ ] Linux user installs the `.deb` (or `.rpm`), plugs in an Azeron, and the app advances past "select your device" without manual `cp` of the udev rules
- [ ] `apt remove` (or `dnf remove`) cleans up `/etc/udev/rules.d/99-azeron.rules`

Closes part of #21 (Linux side; macOS side is in PR #29).